### PR TITLE
add custom events to allow hook'in

### DIFF
--- a/jquery-accessible-carrousel-aria.js
+++ b/jquery-accessible-carrousel-aria.js
@@ -168,6 +168,7 @@
                     "tabindex": 0
                 });
 
+				$carrousel_container.trigger('carrousel:slide-changed');
                 // update of carrouselslide-x-x
                 $carrousel_container = $("#" + hash + ".carrousel__content").parents(".carrousel__container");
 
@@ -203,6 +204,7 @@
                         "aria-selected": "true",
                         "tabindex": 0
                     });
+					$carrousel_container.trigger('carrousel:slide-changed');
                     $first_content.removeAttr("aria-hidden").removeClass('visibility-off');
 
                 }
@@ -260,6 +262,7 @@
                     "aria-selected": "true",
                     "tabindex": 0
                 });
+				$carrousel_container.trigger('carrousel:slide-changed');
                 // add aria-hidden on all tabs
                 $parent.find(".carrousel__content").attr({
                     "aria-hidden": "true"
@@ -476,5 +479,6 @@
 
             });
 
+			$carrousel_container.trigger('carrousel:initialized');
     });
 })(jQuery);


### PR DESCRIPTION
Here is a start for a fix on #11 

2 custom events are triggerd
  * carrousel:initialized after all setup, event listener wiring is done
  * carrousel:slide-changed after a new slide is defined as current

It allows extra customisation: (in my case a pager X/Y)